### PR TITLE
two-finger single-tap zoom out (plus delegate call) like MapKit

### DIFF
--- a/MapView/Map/RMMapTiledLayerView.h
+++ b/MapView/Map/RMMapTiledLayerView.h
@@ -14,7 +14,7 @@
 // points are in the mapview coordinate space
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView singleTapAtPoint:(CGPoint)aPoint;
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView doubleTapAtPoint:(CGPoint)aPoint;
-- (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerDoubleTapAtPoint:(CGPoint)aPoint;
+- (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerTapAtPoint:(CGPoint)aPoint;
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView longPressAtPoint:(CGPoint)aPoint;
 
 @end

--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -14,7 +14,7 @@
 @interface RMMapOverlayView ()
 
 - (void)handleDoubleTap:(UIGestureRecognizer *)recognizer;
-- (void)handleTwoFingerDoubleTap:(UIGestureRecognizer *)recognizer;
+- (void)handleTwoFingerTap:(UIGestureRecognizer *)recognizer;
 
 @end
 
@@ -53,15 +53,15 @@
     UITapGestureRecognizer *singleTapRecognizer = [[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)] autorelease];
     [singleTapRecognizer requireGestureRecognizerToFail:doubleTapRecognizer];
 
-    UITapGestureRecognizer *twoFingerDoubleTapRecognizer = [[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTwoFingerDoubleTap:)] autorelease];
-    twoFingerDoubleTapRecognizer.numberOfTapsRequired = 2;
-    twoFingerDoubleTapRecognizer.numberOfTouchesRequired = 2;
+    UITapGestureRecognizer *twoFingerTapRecognizer = [[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTwoFingerTap:)] autorelease];
+    twoFingerTapRecognizer.numberOfTapsRequired = 1;
+    twoFingerTapRecognizer.numberOfTouchesRequired = 2;
 
     UILongPressGestureRecognizer *longPressRecognizer = [[[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)] autorelease];
 
     [self addGestureRecognizer:singleTapRecognizer];
     [self addGestureRecognizer:doubleTapRecognizer];
-    [self addGestureRecognizer:twoFingerDoubleTapRecognizer];
+    [self addGestureRecognizer:twoFingerTapRecognizer];
     [self addGestureRecognizer:longPressRecognizer];
 
     return self;
@@ -120,10 +120,10 @@
         [delegate mapTiledLayerView:self doubleTapAtPoint:[recognizer locationInView:mapView]];
 }
 
-- (void)handleTwoFingerDoubleTap:(UIGestureRecognizer *)recognizer
+- (void)handleTwoFingerTap:(UIGestureRecognizer *)recognizer
 {
-    if ([delegate respondsToSelector:@selector(mapTiledLayerView:twoFingerDoubleTapAtPoint:)])
-        [delegate mapTiledLayerView:self twoFingerDoubleTapAtPoint:[recognizer locationInView:mapView]];
+    if ([delegate respondsToSelector:@selector(mapTiledLayerView:twoFingerTapAtPoint:)])
+        [delegate mapTiledLayerView:self twoFingerTapAtPoint:[recognizer locationInView:mapView]];
 }
 
 @end

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -102,7 +102,7 @@ typedef enum {
     BOOL _delegateHasAfterMapZoom;
     BOOL _delegateHasMapViewRegionDidChange;
     BOOL _delegateHasDoubleTapOnMap;
-    BOOL _delegateHasDoubleTapTwoFingersOnMap;
+    BOOL _delegateHasTapTwoFingersOnMap;
     BOOL _delegateHasSingleTapOnMap;
     BOOL _delegateHasLongSingleTapOnMap;
     BOOL _delegateHasTapOnAnnotation;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -282,7 +282,7 @@
     _delegateHasMapViewRegionDidChange = [delegate respondsToSelector:@selector(mapViewRegionDidChange:)];
 
     _delegateHasDoubleTapOnMap = [delegate respondsToSelector:@selector(doubleTapOnMap:at:)];
-    _delegateHasDoubleTapTwoFingersOnMap = [delegate respondsToSelector:@selector(doubleTapTwoFingersOnMap:at:)];
+    _delegateHasTapTwoFingersOnMap = [delegate respondsToSelector:@selector(tapTwoFingersOnMap:at:)];
     _delegateHasSingleTapOnMap = [delegate respondsToSelector:@selector(singleTapOnMap:at:)];
     _delegateHasLongSingleTapOnMap = [delegate respondsToSelector:@selector(longSingleTapOnMap:at:)];
 
@@ -1045,12 +1045,12 @@
         [delegate doubleTapOnMap:self at:aPoint];
 }
 
-- (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerDoubleTapAtPoint:(CGPoint)aPoint
+- (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerTapAtPoint:(CGPoint)aPoint
 {
     [self zoomOutToNextNativeZoomAt:aPoint animated:YES];
 
-    if (_delegateHasDoubleTapTwoFingersOnMap)
-        [delegate doubleTapTwoFingersOnMap:self at:aPoint];
+    if (_delegateHasTapTwoFingersOnMap)
+        [delegate tapTwoFingersOnMap:self at:aPoint];
 }
 
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView longPressAtPoint:(CGPoint)aPoint

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -53,7 +53,7 @@
 - (void)mapViewRegionDidChange:(RMMapView *)mapView;
 
 - (void)doubleTapOnMap:(RMMapView *)map at:(CGPoint)point;
-- (void)doubleTapTwoFingersOnMap:(RMMapView *)map at:(CGPoint)point;
+- (void)tapTwoFingersOnMap:(RMMapView *)map at:(CGPoint)point;
 - (void)singleTapOnMap:(RMMapView *)map at:(CGPoint)point;
 - (void)longSingleTapOnMap:(RMMapView *)map at:(CGPoint)point;
 


### PR DESCRIPTION
This changes the two-finger double-tap to be a two-finger single tap, still zooming out and still offering a delegate callback. This is to be more like MapKit. 

I'm curious if there's any reason you chose two-finger double-tap instead? 

Fine if you don't want this, too -- just a suggestion. 
