### PR TITLE
Tilestream support

### DIFF
--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -1,0 +1,94 @@
+//
+//  RMTileStreamSource.h
+//
+//  Created by Justin R. Miller on 5/17/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  http://mapbox.com/hosting/api/
+//
+//  Example usage at https://github.com/mapbox/tilestream-ios-example
+//
+//  This class supports both the paid, hosted version of TileStream, as well as the 
+//  open source, self-hosted version. 
+//
+//  When initializing an instance, pass in an info dictionary comprised of the 
+//  following keys. Unless otherwise specified, keys & values are exactly as 
+//  returned by the TileStream REST API.
+//
+//  Example: http://tiles.mapbox.com/mapbox/api/v1/Tileset/geography-class
+//
+//  Required info dictionary keys:
+//
+//    `name`
+//    `id`
+//    `version`
+//    `description`
+//    `attribution`
+//    `type`
+//    `minzoom`
+//    `maxzoom`
+//    `bounds`
+//    `tileURL` (choose a single value from `tiles` as returned by the API)
+//
+
+#import "RMAbstractWebMapSource.h"
+
+#define kTileStreamDefaultTileSize 256
+#define kTileStreamDefaultMinTileZoom 0
+#define kTileStreamDefaultMaxTileZoom 18
+#define kTileStreamDefaultLatLonBoundingBox ((RMSphericalTrapezium){ .northEast = { .latitude =  90, .longitude =  180 }, \
+                                                                     .southWest = { .latitude = -90, .longitude = -180 } })
+
+typedef enum {
+    RMTileStreamLayerTypeBaselayer = 0,
+    RMTileStreamLayerTypeOverlay   = 1,
+} RMTileStreamLayerType;
+
+@interface RMTileStreamSource : RMAbstractWebMapSource
+{
+    NSDictionary *infoDictionary;
+}
+
+- (id)initWithInfo:(NSDictionary *)info;
+- (id)initWithReferenceURL:(NSURL *)referenceURL;
+//- (NSString *)legend;
+//- (RMTileStreamLayerType)layerType;
+//- (BOOL)coversFullWorld;
+
+@property (nonatomic, readonly, retain) NSDictionary *infoDictionary;
+
+@end
+
+//#pragma mark -
+//
+//@interface RMCachedTileSource (RMTileStreamSourceExtensions)
+//
+//- (NSString *)legend;
+//
+//@end

--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -65,11 +65,6 @@
 #define kTileStreamDefaultLatLonBoundingBox ((RMSphericalTrapezium){ .northEast = { .latitude =  90, .longitude =  180 }, \
                                                                      .southWest = { .latitude = -90, .longitude = -180 } })
 
-typedef enum {
-    RMTileStreamLayerTypeBaselayer = 0,
-    RMTileStreamLayerTypeOverlay   = 1,
-} RMTileStreamLayerType;
-
 @interface RMTileStreamSource : RMAbstractWebMapSource
 {
     NSDictionary *infoDictionary;
@@ -77,18 +72,9 @@ typedef enum {
 
 - (id)initWithInfo:(NSDictionary *)info;
 - (id)initWithReferenceURL:(NSURL *)referenceURL;
-//- (NSString *)legend;
-//- (RMTileStreamLayerType)layerType;
-//- (BOOL)coversFullWorld;
+- (BOOL)coversFullWorld;
+- (NSString *)legend;
 
 @property (nonatomic, readonly, retain) NSDictionary *infoDictionary;
 
 @end
-
-//#pragma mark -
-//
-//@interface RMCachedTileSource (RMTileStreamSourceExtensions)
-//
-//- (NSString *)legend;
-//
-//@end

--- a/MapView/Map/RMTileStreamSource.m
+++ b/MapView/Map/RMTileStreamSource.m
@@ -1,0 +1,181 @@
+//
+//  RMTileStreamSource.h
+//
+//  Created by Justin R. Miller on 5/17/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "RMTileStreamSource.h"
+
+@interface RMTileStreamSource ()
+
+@property (nonatomic, retain) NSDictionary *infoDictionary;
+
+@end
+
+#pragma mark -
+
+@implementation RMTileStreamSource
+
+@synthesize infoDictionary;
+
+- (id)initWithInfo:(NSDictionary *)info
+{
+	if (self = [super init])
+        infoDictionary = [[NSDictionary dictionaryWithDictionary:info] retain];
+    
+	return self;
+}
+
+- (id)initWithReferenceURL:(NSURL *)referenceURL
+{
+    return [self initWithInfo:[NSDictionary dictionaryWithContentsOfURL:referenceURL]];
+}
+
+- (void)dealloc
+{
+    [infoDictionary release];
+    
+    [super dealloc];
+}
+
+#pragma mark 
+
+- (NSURL *)URLForTile:(RMTile)tile
+{
+    // flip y value per OSM-style
+    //
+    NSInteger zoom = tile.zoom;
+    NSInteger x    = tile.x;
+    NSInteger y    = pow(2, zoom) - tile.y - 1;
+    
+    NSString *tileURLString = [self.infoDictionary objectForKey:@"tileURL"];
+    
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{z}" withString:[[NSNumber numberWithInteger:zoom] stringValue]];
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{x}" withString:[[NSNumber numberWithInteger:x]    stringValue]];
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{y}" withString:[[NSNumber numberWithInteger:y]    stringValue]];
+    
+	return [NSURL URLWithString:tileURLString];
+}
+
+- (float)minZoom
+{
+    return [[self.infoDictionary objectForKey:@"minzoom"] floatValue];
+}
+
+- (float)maxZoom
+{
+    return [[self.infoDictionary objectForKey:@"maxzoom"] floatValue];
+}
+
+- (RMSphericalTrapezium)latitudeLongitudeBoundingBox
+{
+    NSArray *parts = [[self.infoDictionary objectForKey:@"bounds"] componentsSeparatedByString:@","];
+        
+    if ([parts count] == 4)
+    {
+        RMSphericalTrapezium bounds = {
+            .southWest = {
+                .longitude = [[parts objectAtIndex:0] doubleValue],
+                .latitude  = [[parts objectAtIndex:1] doubleValue],
+            },
+            .northEast = {
+                .longitude = [[parts objectAtIndex:2] doubleValue],
+                .latitude  = [[parts objectAtIndex:3] doubleValue],
+            },
+        };
+        
+        return bounds;
+    }
+    
+    return kTileStreamDefaultLatLonBoundingBox;
+}
+
+//- (BOOL)coversFullWorld
+//{
+//    RMSphericalTrapezium ownBounds     = [self latitudeLongitudeBoundingBox];
+//    RMSphericalTrapezium defaultBounds = kTileStreamDefaultLatLonBoundingBox;
+//    
+//    if (ownBounds.southwest.longitude <= defaultBounds.southwest.longitude + 10 && 
+//        ownBounds.northeast.longitude >= defaultBounds.northeast.longitude - 10)
+//        return YES;
+//    
+//    return NO;
+//}
+
+- (NSString *)uniqueTilecacheKey
+{
+	return [NSString stringWithFormat:@"%@-%@", [self.infoDictionary objectForKey:@"id"], [self.infoDictionary objectForKey:@"version"]];
+}
+
+- (NSString *)shortName
+{
+	return [self.infoDictionary objectForKey:@"name"];
+}
+
+- (NSString *)longDescription
+{
+	return [self.infoDictionary objectForKey:@"description"];
+}
+
+- (NSString *)shortAttribution
+{
+	return [self.infoDictionary objectForKey:@"attribution"];
+}
+
+- (NSString *)longAttribution
+{
+	return [self shortAttribution];
+}
+
+- (NSString *)legend
+{
+    return [self.infoDictionary objectForKey:@"legend"];
+}
+
+- (RMTileStreamLayerType)layerType
+{
+    return ([[self.infoDictionary objectForKey:@"type"] isEqualToString:@"overlay"] ? RMTileStreamLayerTypeOverlay : RMTileStreamLayerTypeBaselayer);
+}
+
+@end
+
+//#pragma mark -
+//
+//@implementation RMCachedTileSource (RMTileStreamSourceExtensions)
+//
+//- (NSString *)legend
+//{
+//    if ([tileSource isKindOfClass:[RMTileStreamSource class]])
+//        return [(RMTileStreamSource *)tileSource legend];
+//    
+//    return nil;
+//}
+//
+//@end

--- a/MapView/Map/RMTileStreamSource.m
+++ b/MapView/Map/RMTileStreamSource.m
@@ -117,17 +117,22 @@
     return kTileStreamDefaultLatLonBoundingBox;
 }
 
-//- (BOOL)coversFullWorld
-//{
-//    RMSphericalTrapezium ownBounds     = [self latitudeLongitudeBoundingBox];
-//    RMSphericalTrapezium defaultBounds = kTileStreamDefaultLatLonBoundingBox;
-//    
-//    if (ownBounds.southwest.longitude <= defaultBounds.southwest.longitude + 10 && 
-//        ownBounds.northeast.longitude >= defaultBounds.northeast.longitude - 10)
-//        return YES;
-//    
-//    return NO;
-//}
+- (BOOL)coversFullWorld
+{
+    RMSphericalTrapezium ownBounds     = [self latitudeLongitudeBoundingBox];
+    RMSphericalTrapezium defaultBounds = kTileStreamDefaultLatLonBoundingBox;
+    
+    if (ownBounds.southWest.longitude <= defaultBounds.southWest.longitude + 10 && 
+        ownBounds.northEast.longitude >= defaultBounds.northEast.longitude - 10)
+        return YES;
+    
+    return NO;
+}
+
+- (NSString *)legend
+{
+    return [self.infoDictionary objectForKey:@"legend"];
+}
 
 - (NSString *)uniqueTilecacheKey
 {
@@ -154,28 +159,4 @@
 	return [self shortAttribution];
 }
 
-- (NSString *)legend
-{
-    return [self.infoDictionary objectForKey:@"legend"];
-}
-
-- (RMTileStreamLayerType)layerType
-{
-    return ([[self.infoDictionary objectForKey:@"type"] isEqualToString:@"overlay"] ? RMTileStreamLayerTypeOverlay : RMTileStreamLayerTypeBaselayer);
-}
-
 @end
-
-//#pragma mark -
-//
-//@implementation RMCachedTileSource (RMTileStreamSourceExtensions)
-//
-//- (NSString *)legend
-//{
-//    if ([tileSource isKindOfClass:[RMTileStreamSource class]])
-//        return [(RMTileStreamSource *)tileSource legend];
-//    
-//    return nil;
-//}
-//
-//@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		B8F3FC650EA2E792004D8F85 /* RMMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B8F3FC630EA2E792004D8F85 /* RMMarker.m */; };
 		D1437B36122869E400888DAE /* RMDBMapSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D1437B32122869E400888DAE /* RMDBMapSource.m */; };
 		D1437B37122869E400888DAE /* RMDBMapSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D1437B33122869E400888DAE /* RMDBMapSource.h */; };
+		DD98B6FA14D76B930092882F /* RMTileStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD98B6F814D76B930092882F /* RMTileStreamSource.h */; };
+		DD98B6FB14D76B930092882F /* RMTileStreamSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD98B6F914D76B930092882F /* RMTileStreamSource.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -280,6 +282,8 @@
 		B8F3FC630EA2E792004D8F85 /* RMMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMarker.m; sourceTree = "<group>"; };
 		D1437B32122869E400888DAE /* RMDBMapSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMDBMapSource.m; sourceTree = "<group>"; };
 		D1437B33122869E400888DAE /* RMDBMapSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDBMapSource.h; sourceTree = "<group>"; };
+		DD98B6F814D76B930092882F /* RMTileStreamSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileStreamSource.h; sourceTree = "<group>"; };
+		DD98B6F914D76B930092882F /* RMTileStreamSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileStreamSource.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -490,6 +494,8 @@
 				16EC85CD133CA6C300219947 /* RMAbstractMercatorTileSource.m */,
 				16EC85CE133CA6C300219947 /* RMAbstractWebMapSource.h */,
 				16EC85CF133CA6C300219947 /* RMAbstractWebMapSource.m */,
+				DD98B6F814D76B930092882F /* RMTileStreamSource.h */,
+				DD98B6F914D76B930092882F /* RMTileStreamSource.m */,
 			);
 			name = "Tile Source";
 			sourceTree = "<group>";
@@ -627,6 +633,7 @@
 				160E535713FBDB48004F82F9 /* RMMapTiledLayerView.h in Headers */,
 				1609AF8E14068B09008344B7 /* RMMapOverlayView.h in Headers */,
 				16128CF5148D295300C23C0E /* RMOpenSeaMapSource.h in Headers */,
+				DD98B6FA14D76B930092882F /* RMTileStreamSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -840,6 +847,7 @@
 				160E535813FBDB48004F82F9 /* RMMapTiledLayerView.m in Sources */,
 				1609AF8F14068B09008344B7 /* RMMapOverlayView.m in Sources */,
 				16128CF6148D295300C23C0E /* RMOpenSeaMapSource.m in Sources */,
+				DD98B6FB14D76B930092882F /* RMTileStreamSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Similar to #10 MBTiles support, here is [TileStream](https://github.com/mapbox/tilestream) server support for remote tiles as adapted from route-me core. To try it out, init a tile source with a file such as https://github.com/incanus/Mapresent/blob/master/Mapresent/mapbox.geography-class.plist containing info obtained from the [MapBox API](http://mapbox.com/hosting/api/) and remote tiles will be fetched. 
