### PR TITLE
configurable pan/zoom animation durations

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -57,6 +57,7 @@ typedef enum {
 @class RMMarker;
 @class RMAnnotation;
 @class RMQuadTree;
+@class RMScrollView;
 @protocol RMMercatorToTileProjection;
 @protocol RMTileSource;
 @protocol RMMapTiledLayerViewDelegate;
@@ -72,7 +73,7 @@ typedef enum {
 
     /// subview for the background image displayed while tiles are loading. Set its contents by providing your own "loading.png".
     UIView *backgroundView;
-    UIScrollView *mapScrollView;
+    RMScrollView *mapScrollView;
     RMMapTiledLayerView *tiledLayerView;
     RMMapOverlayView *overlayView;
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -42,6 +42,7 @@
 #import "RMTileCache.h"
 #import "RMTileSource.h"
 
+#import "RMScrollView.h"
 #import "RMMapTiledLayerView.h"
 #import "RMMapOverlayView.h"
 
@@ -883,7 +884,7 @@
     int tileSideLength = [[self tileSource] tileSideLength];
     CGSize contentSize = CGSizeMake(tileSideLength, tileSideLength); // zoom level 1
 
-    mapScrollView = [[UIScrollView alloc] initWithFrame:[self bounds]];
+    mapScrollView = [[RMScrollView alloc] initWithFrame:[self bounds]];
     mapScrollView.delegate = self;
     mapScrollView.opaque = NO;
     mapScrollView.backgroundColor = [UIColor clearColor];

--- a/MapView/Map/RMScrollView.h
+++ b/MapView/Map/RMScrollView.h
@@ -1,0 +1,16 @@
+//
+//  RMScrollView.h
+//  MapView
+//
+//  Created by Justin Miller on 1/30/12.
+//  Copyright (c) 2012 Development Seed. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface RMScrollView : UIScrollView
+
+- (void)setContentOffset:(CGPoint)contentOffset animatedWithDuration:(NSTimeInterval)duration;
+- (void)zoomToRect:(CGRect)rect animatedWithDuration:(NSTimeInterval)duration;
+
+@end

--- a/MapView/Map/RMScrollView.m
+++ b/MapView/Map/RMScrollView.m
@@ -1,0 +1,37 @@
+//
+//  RMScrollView.m
+//  MapView
+//
+//  Created by Justin Miller on 1/30/12.
+//  Copyright (c) 2012 Development Seed. All rights reserved.
+//
+
+#import "RMScrollView.h"
+
+@implementation RMScrollView
+
+- (void)setContentOffset:(CGPoint)contentOffset animatedWithDuration:(NSTimeInterval)duration
+{
+    [UIView animateWithDuration:duration
+                          delay:0
+                        options:UIViewAnimationOptionBeginFromCurrentState & UIViewAnimationCurveEaseInOut
+                     animations:^(void)
+                     {
+                         [super setContentOffset:contentOffset animated:NO];
+                     } 
+                     completion:nil];
+}
+
+- (void)zoomToRect:(CGRect)rect animatedWithDuration:(NSTimeInterval)duration
+{
+    [UIView animateWithDuration:duration
+                          delay:0
+                        options:UIViewAnimationOptionBeginFromCurrentState & UIViewAnimationCurveEaseInOut
+                     animations:^(void)
+                     {
+                         [super zoomToRect:rect animated:NO];
+                     } 
+                     completion:nil];
+}
+
+@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		B8F3FC650EA2E792004D8F85 /* RMMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = B8F3FC630EA2E792004D8F85 /* RMMarker.m */; };
 		D1437B36122869E400888DAE /* RMDBMapSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D1437B32122869E400888DAE /* RMDBMapSource.m */; };
 		D1437B37122869E400888DAE /* RMDBMapSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D1437B33122869E400888DAE /* RMDBMapSource.h */; };
+		DD7582CD14D77A2700DD8D5E /* RMScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = DD7582CB14D77A2700DD8D5E /* RMScrollView.h */; };
+		DD7582CE14D77A2700DD8D5E /* RMScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = DD7582CC14D77A2700DD8D5E /* RMScrollView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -280,6 +282,8 @@
 		B8F3FC630EA2E792004D8F85 /* RMMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMarker.m; sourceTree = "<group>"; };
 		D1437B32122869E400888DAE /* RMDBMapSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMDBMapSource.m; sourceTree = "<group>"; };
 		D1437B33122869E400888DAE /* RMDBMapSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDBMapSource.h; sourceTree = "<group>"; };
+		DD7582CB14D77A2700DD8D5E /* RMScrollView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMScrollView.h; sourceTree = "<group>"; };
+		DD7582CC14D77A2700DD8D5E /* RMScrollView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMScrollView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -447,6 +451,8 @@
 			children = (
 				B83E64D80E80E73F001663B6 /* RMTileImage.h */,
 				B83E64D90E80E73F001663B6 /* RMTileImage.m */,
+				DD7582CB14D77A2700DD8D5E /* RMScrollView.h */,
+				DD7582CC14D77A2700DD8D5E /* RMScrollView.m */,
 				160E535513FBDB47004F82F9 /* RMMapTiledLayerView.h */,
 				160E535613FBDB48004F82F9 /* RMMapTiledLayerView.m */,
 				1609AF8C14068B09008344B7 /* RMMapOverlayView.h */,
@@ -627,6 +633,7 @@
 				160E535713FBDB48004F82F9 /* RMMapTiledLayerView.h in Headers */,
 				1609AF8E14068B09008344B7 /* RMMapOverlayView.h in Headers */,
 				16128CF5148D295300C23C0E /* RMOpenSeaMapSource.h in Headers */,
+				DD7582CD14D77A2700DD8D5E /* RMScrollView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -840,6 +847,7 @@
 				160E535813FBDB48004F82F9 /* RMMapTiledLayerView.m in Sources */,
 				1609AF8F14068B09008344B7 /* RMMapOverlayView.m in Sources */,
 				16128CF6148D295300C23C0E /* RMOpenSeaMapSource.m in Sources */,
+				DD7582CE14D77A2700DD8D5E /* RMScrollView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Here's a patch you might be interested in that allows for variable durations on map pans & zooms. The default for `UIScrollView` is (I believe) `0.3s` but this allows for any duration, as well as mid-stream changes using `UIViewAnimationOptionBeginFromCurrentState`. 
