### PR TITLE
refs #23: use NSURLConnection for network tile fetches

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.h
+++ b/MapView/Map/RMAbstractWebMapSource.h
@@ -29,7 +29,7 @@
 #import "RMProjection.h"
 
 #define RMAbstractWebMapSourceRetryCount  3
-#define RMAbstractWebMapSourceWaitSeconds 2
+#define RMAbstractWebMapSourceWaitSeconds 2.0f
 
 @interface RMAbstractWebMapSource : RMAbstractMercatorTileSource
 

--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -87,8 +87,13 @@
             for (int try = 0; try < RMAbstractWebMapSourceRetryCount; try++)
             {
                 if ( ! tileData)
-                    // Beware: dataWithContentsOfURL is leaking like hell. Better use AFNetwork or ASIHTTPRequest
-                    tileData = [NSData dataWithContentsOfURL:currentURL options:NSDataReadingUncached error:NULL];
+                {
+                    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:currentURL];
+                    
+                    [request setTimeoutInterval:(RMAbstractWebMapSourceWaitSeconds / (CGFloat)RMAbstractWebMapSourceRetryCount)];
+                    
+                    tileData = [NSURLConnection sendSynchronousRequest:request returningResponse:nil error:nil];
+                }
             }
 
             if (tileData)


### PR DESCRIPTION
This uses `NSURLConnection` for tile fetches, with a timeout equal to the desired compositing wait time divided by the number of retries that will be performed, so as to not exceed the desired wait time. It does not solve the problem of an ultimately failed download, however. 
