### PR TITLE
better tile notifications on main queue & with tile reference hashes

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -61,7 +61,10 @@
     if (image)
         return image;
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:nil];
+    dispatch_async(dispatch_get_main_queue(), ^(void)
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+    });
 
     [tileCache retain];
 
@@ -93,12 +96,12 @@
 
             if (tileData)
             {
-                dispatch_sync(dispatch_get_main_queue(), ^(void)
+                @synchronized(self)
                 {
                     // safely put into collection array in proper order
                     //
                     [tilesData replaceObjectAtIndex:u withObject:tileData];
-                });
+                };
             }
         });
     }
@@ -135,7 +138,10 @@
 
     [tileCache release];
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:nil];
+    dispatch_async(dispatch_get_main_queue(), ^(void)
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+    });
 
     if (!image)
         return [RMTileImage errorTile];

--- a/MapView/Map/RMMBTilesTileSource.m
+++ b/MapView/Map/RMMBTilesTileSource.m
@@ -96,6 +96,11 @@
     NSInteger x    = tile.x;
     NSInteger y    = pow(2, zoom) - tile.y - 1;
 
+    dispatch_async(dispatch_get_main_queue(), ^(void)
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+    });
+    
     __block UIImage *image;
 
     [queue inDatabase:^(FMDatabase *db)
@@ -119,6 +124,11 @@
 
         [results close];
     }];
+
+    dispatch_async(dispatch_get_main_queue(), ^(void)
+    {
+        [[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:[NSNumber numberWithUnsignedLongLong:RMTileKey(tile)]];
+    });
 
     return image;
 }


### PR DESCRIPTION
This does three things: 
1. This adds proper tile request/retrieve notifications for the MBTiles tile source (despite being local, it's still nice to know that tiles are loading). 
2. This makes sure to post all notifications on the main thread, since tile image fetches don't always happen there due to `CATiledLayer`. 
3. This posts an `NSNumber` object with a tile's key to indicate which tile is being referred to, rather than `nil` for all notifications. 
