### PR TITLE
configurable cache expiration handling

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -43,5 +43,6 @@
 - (void)setPurgeStrategy:(RMCachePurgeStrategy)theStrategy;
 - (void)setCapacity:(NSUInteger)theCapacity;
 - (void)setMinimalPurge:(NSUInteger)thePurgeMinimum;
+- (void)setExpiryPeriod:(NSTimeInterval)theExpiryPeriod;
 
 @end

--- a/MapView/Map/RMTileCache.h
+++ b/MapView/Map/RMTileCache.h
@@ -65,7 +65,10 @@ typedef enum {
     // This one has its own variable because we want to propagate cache hits down in
     // the cache hierarchy up to the memory cache
     RMMemoryCache *memoryCache;    
+    NSTimeInterval expiryPeriod;
 }
+
+- (id)initWithExpiryPeriod:(NSTimeInterval)period;
 
 + (NSNumber *)tileHash:(RMTile)tile;
 

--- a/MapView/Map/RMTileCache.m
+++ b/MapView/Map/RMTileCache.m
@@ -41,13 +41,14 @@
 
 @implementation RMTileCache
 
-- (id)init
+- (id)initWithExpiryPeriod:(NSTimeInterval)period
 {
 	if (!(self = [super init]))
 		return nil;
 
 	caches = [[NSMutableArray alloc] init];
     memoryCache = nil;
+    expiryPeriod = period;
     
 	id cacheCfg = [[RMConfiguration configuration] cacheConfiguration];	
 	if (!cacheCfg)
@@ -85,6 +86,14 @@
 	}
 
 	return self;
+}
+
+- (id)init
+{
+    if (!(self = [self initWithExpiryPeriod:0]))
+        return nil;
+    
+    return self;
 }
 
 - (void)dealloc
@@ -230,11 +239,16 @@
             RMLog(@"minimalPurge must be at least one and at most the cache capacity");
         }
     }
+    
+    NSNumber *expiryPeriodNumber = [cfg objectForKey:@"expiryPeriod"];
+    if (expiryPeriodNumber != nil)
+        expiryPeriod = [expiryPeriodNumber intValue];
 
     RMDatabaseCache *dbCache = [[[RMDatabaseCache alloc] initUsingCacheDir:useCacheDir] autorelease];
     [dbCache setCapacity:capacity];
     [dbCache setPurgeStrategy:strategy];
     [dbCache setMinimalPurge:minimalPurge];
+    [dbCache setExpiryPeriod:expiryPeriod];
 
     return dbCache;
 }


### PR DESCRIPTION
This is some functionality to provide for time-based tile cache removal. It adds an `expiryPeriod` property to `RMDatabaseCache` (this doesn't really make sense for memory cache). It also adjusts `RMTileCache` to setup the database cache with an `expiryPeriod` of zero by default, which means not to use the time-based cache (and makes the quantity-based cache check first that time-based isn't used), as well as adds parsing to the file-based configuration options to set `expiryPeriod` there. It uses a 1% garbage collection frequency to do the actual time-based cache purging, as well as the already existent `last_used` column in the database store, which doesn't get updated unless the LRU purge method is being used. 
