### PR TITLE
annotation layer fixes

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1755,15 +1755,13 @@
     {
         [self correctScreenPosition:annotation];
 
-        if ([annotation isAnnotationOnScreen] && [delegate respondsToSelector:@selector(mapView:layerForAnnotation:)])
-        {
+        if (annotation.layer == nil && [annotation isAnnotationOnScreen] && _delegateHasLayerForAnnotation)
             annotation.layer = [delegate mapView:self layerForAnnotation:annotation];
 
-            if (annotation.layer)
-            {
-                [overlayView addSublayer:annotation.layer];
-                [visibleAnnotations addObject:annotation];
-            }
+        if (annotation.layer)
+        {
+            [overlayView addSublayer:annotation.layer];
+            [visibleAnnotations addObject:annotation];
         }
     }
 }


### PR DESCRIPTION
This is a quick fix that came of the location services stuff for when an annotation has a manual layer provided. Otherwise, the delegate will be consulted and overwrite any layer already set when making the annotation before adding it. 

It also makes use of the `_delegateHasLayerForAnnotation` variable as is standard elsewhere. 
