### PR TITLE
two-finger gestures should zoom out on map center, not touch center

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1122,7 +1122,7 @@
 
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerDoubleTapAtPoint:(CGPoint)aPoint
 {
-    [self zoomOutToNextNativeZoomAt:aPoint animated:YES];
+    [self zoomOutToNextNativeZoomAt:self.center animated:YES];
 
     if (_delegateHasDoubleTapTwoFingersOnMap)
         [delegate doubleTapTwoFingersOnMap:self at:aPoint];
@@ -1130,7 +1130,7 @@
 
 - (void)mapTiledLayerView:(RMMapTiledLayerView *)aTiledLayerView twoFingerSingleTapAtPoint:(CGPoint)aPoint
 {
-    [self zoomOutToNextNativeZoomAt:aPoint animated:YES];
+    [self zoomOutToNextNativeZoomAt:self.center animated:YES];
 
     if (_delegateHasSingleTapTwoFingersOnMap)
         [delegate singleTapTwoFingersOnMap:self at:aPoint];


### PR DESCRIPTION
Makes behavior more like MapKit, where two-finger taps zoom out at the current map center, not the touch center. This comes into play with #59 location services since eventually, any tracking modes should stay enabled, but this isn't possible when the map center changes. 

Aside: take all of these pull requests (I know I've opened several lately) with a grain of salt and don't feel the need to add them to your project if they don't suit you. All are just suggestions. :-)
