### PR TITLE
marker label tap fix

### DIFF
--- a/MapView/Map/RMMapOverlayView.m
+++ b/MapView/Map/RMMapOverlayView.m
@@ -106,10 +106,12 @@
 
     CALayer *hit = [self.layer hitTest:point];
 
-    if (!hit || ![hit isKindOfClass:[RMMarker class]])
+    RMAnnotation *hitAnnotation = [self findAnnotationInLayer:hit];
+    
+    if (!hit || !hitAnnotation || ![hitAnnotation.layer isKindOfClass:[RMMarker class]])
         return NO;
 
-    return ((RMMarker *)hit).annotation.enabled;
+    return hitAnnotation.enabled;
 }
 
 - (RMAnnotation *)findAnnotationInLayer:(CALayer *)layer


### PR DESCRIPTION
This should fix #6 marker label taps. The problem was that `RMMapOverlayView`'s override of `pointInside:withEvent:`, which keeps the overlay view from registering taps in empty, non-overlay areas, was only registering for `RMMarker` taps. This fix uses the internal `findAnnotationInLayer:` to get at the root annotation being referenced (whether tapping marker or label), then moves on from there. 

It also still checks that the annotation's layer is an `RMMarker` so that path & circle, etc. taps still do not register. 
