### PR TITLE
double tap passthrough

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1064,10 +1064,7 @@
     }
     else
     {
-        [self zoomInToNextNativeZoomAt:aPoint animated:YES];
-
-        if (_delegateHasDoubleTapOnMap)
-            [delegate doubleTapOnMap:self at:aPoint];
+        [self mapTiledLayerView:tiledLayerView doubleTapAtPoint:aPoint];
     }
 }
 
@@ -1092,10 +1089,7 @@
     }
     else
     {
-        [self zoomInToNextNativeZoomAt:aPoint animated:YES];
-
-        if (_delegateHasDoubleTapOnMap)
-            [delegate doubleTapOnMap:self at:aPoint];
+        [self mapTiledLayerView:tiledLayerView doubleTapAtPoint:aPoint];
     }
 }
 


### PR DESCRIPTION
This eliminates some redundant code when passing along annotation double-taps to the underlying tiled layer. This simplifies the addition of [this feature](https://github.com/Alpstein/route-me/issues/59#issuecomment-6099596) since both types of double-taps need to be recognized and evaluated in that case, and performing the `center` check code in two places is undesirable. 
