### PR TITLE
pass annotation label taps to annotation if not handled in delegate

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1074,6 +1074,10 @@
     {
         [delegate tapOnLabelForAnnotation:anAnnotation onMap:self];
     }
+    else if (_delegateHasTapOnAnnotation && anAnnotation)
+    {
+        [delegate tapOnAnnotation:anAnnotation onMap:self];
+    }
     else
     {
         if (_delegateHasSingleTapOnMap)
@@ -1086,6 +1090,10 @@
     if (_delegateHasDoubleTapOnLabelForAnnotation && anAnnotation)
     {
         [delegate doubleTapOnLabelForAnnotation:anAnnotation onMap:self];
+    }
+    else if (_delegateHasDoubleTapOnAnnotation && anAnnotation)
+    {
+        [delegate doubleTapOnAnnotation:anAnnotation onMap:self];
     }
     else
     {


### PR DESCRIPTION
I very frequently find myself implementing an annotation tap delegate callback, then redundantly implementing the label tap callback just to pass the tap back to the main annotation one, since I don't care if the user taps the marker or the marker label. This change makes that the default behavior if the developer doesn't implement marker label tap handling. 
