### PR TITLE
added debug tiles switch

### DIFF
--- a/MapView/Map/RMMapTiledLayerView.m
+++ b/MapView/Map/RMMapTiledLayerView.m
@@ -179,6 +179,38 @@
             }
         }
 
+        if (mapView.debugTiles)
+        {
+            UIGraphicsBeginImageContext(tileImage.size);
+
+            CGContextRef debugContext = UIGraphicsGetCurrentContext();
+            
+            CGRect debugRect = CGRectMake(0, 0, tileImage.size.width, tileImage.size.height);
+            
+            [tileImage drawInRect:debugRect];
+            
+            CGColorRef color = CGColorCreateCopyWithAlpha([[UIColor redColor] CGColor], 0.25);
+            
+            UIFont *font = [UIFont systemFontOfSize:36];
+            
+            CGContextSetStrokeColorWithColor(debugContext, color);
+            CGContextSetLineWidth(debugContext, 5);
+            
+            CGContextStrokeRect(debugContext, debugRect);
+            
+            CGContextSetFillColorWithColor(debugContext, color);
+            
+            NSString *debugString = [NSString stringWithFormat:@"%i,%i,%i", zoom, x, y];
+            
+            CGSize debugSize = [debugString sizeWithFont:font];
+            
+            [debugString drawInRect:CGRectMake(5, 5, debugSize.width, debugSize.height) withFont:font];
+            
+            tileImage = UIGraphicsGetImageFromCurrentImageContext();
+
+            UIGraphicsEndImageContext();
+        }
+        
         [tileImage drawInRect:rect];
 
         UIGraphicsPopContext();

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -144,6 +144,8 @@ typedef enum {
 /// subview for the background image displayed while tiles are loading.
 @property (nonatomic, retain) UIView *backgroundView;
 
+@property (nonatomic, assign) BOOL debugTiles;
+
 #pragma mark -
 #pragma mark Initializers
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -118,6 +118,7 @@
 @synthesize enableClustering, positionClusterMarkersAtTheGravityCenter, clusterMarkerSize, clusterAreaSize;
 @synthesize adjustTilesForRetinaDisplay;
 @synthesize missingTilesDepth;
+@synthesize debugTiles;
 
 #pragma mark -
 #pragma mark Initialization
@@ -1559,6 +1560,15 @@
 - (RMFractalTileProjection *)mercatorToTileProjection
 {
     return [[mercatorToTileProjection retain] autorelease];
+}
+
+- (void)setDebugTiles:(BOOL)shouldDebug;
+{
+    debugTiles = shouldDebug;
+    
+    tiledLayerView.layer.contents = nil;
+    
+    [tiledLayerView.layer setNeedsDisplay];
 }
 
 #pragma mark -


### PR DESCRIPTION
This adds a `BOOL` to the map view to allow for border highlighting and `z/x/y` labeling of tile images, which can help in debugging. Defaults to off, of course. 
