### PR TITLE
Set shouldRasterize to improve performance

### DIFF
--- a/MapView/Map/RMShape.m
+++ b/MapView/Map/RMShape.m
@@ -109,7 +109,16 @@
         return;
 
     float scale = 1.0f / [mapView metersPerPixel];
-
+    
+    if (animated || scale != lastScale)
+    {
+        self.shouldRasterize = NO;
+    }
+    else
+    {
+        self.shouldRasterize = YES;
+    }
+    
     // we have to calculate the scaledLineWidth even if scalling did not change
     // as the lineWidth might have changed
     float scaledLineWidth;


### PR DESCRIPTION
Improves performance when scrolling by rasterizing path to an image.
