### PR TITLE
RMShape shadow

### DIFF
--- a/MapView/Map/RMShape.h
+++ b/MapView/Map/RMShape.h
@@ -60,6 +60,9 @@
 @property (nonatomic, assign) BOOL scaleLineDash;
 @property (nonatomic, assign) float lineWidth;
 @property (nonatomic, assign) BOOL	scaleLineWidth;
+@property (nonatomic, assign) CGFloat shadowBlur;
+@property (nonatomic, assign) CGSize shadowOffset;
+@property (nonatomic, assign) BOOL enableShadow;
 
 @property (nonatomic, readonly) CGRect pathBoundingBox;
 

--- a/MapView/Map/RMShape.m
+++ b/MapView/Map/RMShape.m
@@ -48,6 +48,9 @@
 @synthesize scaleLineWidth;
 @synthesize lineDashLengths;
 @synthesize scaleLineDash;
+@synthesize shadowBlur;
+@synthesize shadowOffset;
+@synthesize enableShadow;
 @synthesize pathBoundingBox;
 
 #define kDefaultLineWidth 2.0
@@ -70,6 +73,9 @@
     shapeLayer.lineJoin = kCALineJoinMiter;
     shapeLayer.strokeColor = [UIColor blackColor].CGColor;
     shapeLayer.fillColor = [UIColor clearColor].CGColor;
+    shapeLayer.shadowRadius = 0.0;
+    shapeLayer.shadowOpacity = 0.0;
+    shapeLayer.shadowOffset = CGSizeMake(0, 0);
     [self addSublayer:shapeLayer];
 
     pathBoundingBox = CGRectZero;
@@ -411,6 +417,40 @@
         shapeLayer.fillColor = aFillColor.CGColor;
         [self setNeedsDisplay];
     }
+}
+
+- (CGFloat)shadowBlur
+{
+    return shapeLayer.shadowRadius;
+}
+
+- (void)setShadowBlur:(CGFloat)blur
+{
+    shapeLayer.shadowRadius = blur;
+    [self setNeedsDisplay];
+}
+
+- (CGSize)shadowOffset
+{
+    return shapeLayer.shadowOffset;
+}
+
+- (void)setShadowOffset:(CGSize)offset
+{
+    shapeLayer.shadowOffset = offset;
+    [self setNeedsDisplay];
+}
+
+- (BOOL)enableShadow
+{
+    return (shapeLayer.shadowOpacity > 0);
+}
+
+- (void)setEnableShadow:(BOOL)flag
+{
+    shapeLayer.shadowOpacity   = (flag ? 1.0 : 0.0);
+    shapeLayer.shouldRasterize = ! flag;
+    [self setNeedsDisplay];
 }
 
 - (NSString *)fillRule

--- a/MapView/Map/RMShape.m
+++ b/MapView/Map/RMShape.m
@@ -172,7 +172,7 @@
 
         // calculate the bounds of the scaled path
         CGRect boundsInMercators = scaledPath.bounds;
-        nonClippedBounds = CGRectInset(boundsInMercators, -scaledLineWidth, -scaledLineWidth);
+        nonClippedBounds = CGRectInset(boundsInMercators, -scaledLineWidth - (2 * shapeLayer.shadowRadius), -scaledLineWidth - (2 * shapeLayer.shadowRadius));
 
         [scaledPath release];
     }


### PR DESCRIPTION
This refs my comment on #44 and adds analogous settings to `RMShape` like `RMPath` has for shadows. Performance has room for improvement when zooming/scaling (even more so than the `shouldRasterize` that I've done) but it's a start and behaves as expected. 
