### PR TITLE
remove unneeded log & fix build warning

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -928,9 +928,6 @@
         myOrigin.y = myOrigin.y - (zoomRect.size.height / 2);
         zoomRect.origin = myOrigin;
 
-        RMProjectedPoint topRight = RMProjectedPointMake(myOrigin.x + zoomRect.size.width, myOrigin.y + zoomRect.size.height);
-        RMLog(@"zoomWithBoundingBox: {%f,%f} - {%f,%f}", [_projection projectedPointToCoordinate:myOrigin].longitude, [_projection projectedPointToCoordinate:myOrigin].latitude, [_projection projectedPointToCoordinate:topRight].longitude, [_projection projectedPointToCoordinate:topRight].latitude);
-
         [self setProjectedBounds:zoomRect animated:animated];
     }
 }


### PR DESCRIPTION
This log message isn't really needed, and by extension, neither is `topRight`, which gives a weird build warning in Xcode despite being used, probably due to nulling of `RMLog`. See also mapbox/mapbox-ios-sdk#53
