### PR TITLE
fix crash when attempting at add nil tileSource

### DIFF
--- a/MapView/Map/RMTileSourcesContainer.m
+++ b/MapView/Map/RMTileSourcesContainer.m
@@ -124,6 +124,9 @@
 
 - (BOOL)addTileSource:(id<RMTileSource>)tileSource atIndex:(NSUInteger)index
 {
+    if ( ! tileSource)
+        return NO;
+    
     [_tileSourcesLock lock];
 
     RMProjection *newProjection = [tileSource projection];


### PR DESCRIPTION
Does what it says on the tin. I've seen this sort of thing in relation to [something like this](https://github.com/mapbox/mapbox-me/blob/master/MapBox%20Me/MBMViewController.m#L49) where a network-fetch-based tile source comes back empty. While this is developer error for not providing an online/offline check and/or alternative layer, avoiding a crash would be nice, too. 
