### PR TITLE
only rotate marker annotations when rotating map view

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2541,10 +2541,7 @@
                                  _overlayView.transform   = CGAffineTransformIdentity;
                                  
                                  for (RMAnnotation *annotation in _annotations)
-                                 {
-                                     if ( ! annotation.isUserLocationAnnotation)
-                                         annotation.layer.transform = CATransform3DIdentity;
-                                 }
+                                     annotation.layer.transform = CATransform3DIdentity;
                              }
                              completion:nil];
 
@@ -2586,10 +2583,7 @@
                                  _overlayView.transform   = CGAffineTransformIdentity;
 
                                  for (RMAnnotation *annotation in _annotations)
-                                 {
-                                     if ( ! annotation.isUserLocationAnnotation)
-                                         annotation.layer.transform = CATransform3DIdentity;
-                                 }
+                                     annotation.layer.transform = CATransform3DIdentity;
                              }
                              completion:nil];
 
@@ -2800,10 +2794,8 @@
                              _overlayView.transform   = CGAffineTransformMakeRotation(angle);
 
                              for (RMAnnotation *annotation in _annotations)
-                             {
-                                 if ( ! annotation.isUserLocationAnnotation)
+                                 if ([annotation.layer isKindOfClass:[RMMarker class]] && ! annotation.isUserLocationAnnotation)
                                      annotation.layer.transform = CATransform3DMakeAffineTransform(CGAffineTransformMakeRotation(-angle));
-                             }
                          }
                          completion:nil];
 


### PR DESCRIPTION
This is a minor fix that came out of mapbox/mapbox-ios-sdk#57, where paths etc. were being rotated about their `coordinate`. They shouldn't get rotated explicitly at all, and should just "ride along" with the overlay view when it follows the map. Only `RMMarker` annotations should rotate about their coordinate in order to remain "upright". 
