### PR TITLE
refs mapbox/mapbox-ios-sdk#55: properly center user location on rotates

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2602,6 +2602,11 @@
             userHeadingTrackingView.center = CGPointMake(round([self bounds].size.width  / 2), 
                                                          round([self bounds].size.height / 2) - (userHeadingTrackingView.bounds.size.height / 2) - 4);
 
+            userHeadingTrackingView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin  |
+                                                       UIViewAutoresizingFlexibleRightMargin |
+                                                       UIViewAutoresizingFlexibleTopMargin   |
+                                                       UIViewAutoresizingFlexibleBottomMargin;
+
             userHeadingTrackingView.alpha = 0.0;
 
             [self addSubview:userHeadingTrackingView];
@@ -2613,6 +2618,11 @@
             userLocationTrackingView.center = CGPointMake(round([self bounds].size.width  / 2), 
                                                           round([self bounds].size.height / 2));
 
+            userLocationTrackingView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin  |
+                                                        UIViewAutoresizingFlexibleRightMargin |
+                                                        UIViewAutoresizingFlexibleTopMargin   |
+                                                        UIViewAutoresizingFlexibleBottomMargin;
+            
             [self addSubview:userLocationTrackingView];
 
             if (self.zoom < 3)


### PR DESCRIPTION
When the device is rotated during heading tracking mode, the user location images don't properly recenter in the view. This fixes it by properly using `UIView` autoresizing. 
