### PR TITLE
fix normal scrolling of map when annotations can be dragged

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -1400,6 +1400,9 @@
         // check whether our custom pan gesture recognizer should start recognizing the gesture
         CALayer *hit = [_overlayView.layer hitTest:[recognizer locationInView:_overlayView]];
 
+        if ([hit isEqual:_overlayView.layer])
+            return NO;
+        
         if (!hit || ([hit respondsToSelector:@selector(enableDragging)] && ![(RMMarker *)hit enableDragging]))
             return NO;
 


### PR DESCRIPTION
I had not done anything with dragging annotations yet, but when I tried, I noticed that any annotations with `enableDragging` turned on would cause the map view itself to no longer be scrollable. This fix notices when the annotation drag `UIPanGestureRecognizer` is hitting just the overlay and not an actual annotation and bails out in order to allow the default scrollview `UIPanGestureRecognizer` to work. 
