### PR TITLE
Fix CLLocationManager management

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -335,6 +335,8 @@
 {
     LogMethod();
 
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+
     [self setDelegate:nil];
     [self setBackgroundView:nil];
     [self setQuadTree:nil];
@@ -2455,6 +2457,9 @@
         _locationManager.headingFilter = 5;
         _locationManager.delegate = self;
         [_locationManager startUpdatingLocation];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackground:)  name:UIApplicationDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
     }
     else
     {
@@ -2463,6 +2468,9 @@
         _locationManager.delegate = nil;
         [_locationManager release];
         _locationManager = nil;
+
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
 
         if (_delegateHasDidStopLocatingUser)
             [_delegate mapViewDidStopLocatingUser:self];
@@ -2821,6 +2829,26 @@
         if (_delegateHasDidFailToLocateUserWithError)
             [_delegate mapView:self didFailToLocateUserWithError:error];
     }
+}
+
+#pragma mark -
+#pragma mark system events
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  if (_locationManager != nil) {
+    [_locationManager stopUpdatingLocation];
+    [_locationManager stopUpdatingHeading];
+  }
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+  if (_locationManager != nil) {
+    if (_showsUserLocation == YES)
+      [_locationManager startUpdatingLocation];
+    
+    if (_userTrackingMode == RMUserTrackingModeFollowWithHeading)
+      [_locationManager startUpdatingHeading];
+  }
 }
 
 @end


### PR DESCRIPTION
Hi,

there is a bug in Alpstein/route-me management of CLLocationManager.

Basically, if userTrackingMode is set to either RMUserTrackingModeFollow or RMUserTrackingModeFollowWithHeading, a CLLocationManager is instantiated to keep track of location changes.

So far so good.

However, if application is registered to get location updates in background, when application enters background mode, this location manager does not get deactivated, meaning that the GPS receives is kept active, draining the battery needlessly.

I'll explain better with an example. I have an application (EasyTrails, basically a GPS tracker) that is registered to receive location updates in background. However, I keep the location manager active in background only while the user is actually recording a track, otherwise the application will be sent to background just like any other application. Your use of CLLocationManager disrupts this behavior, since your instance of CLLocationManager does not get deactivated when application goes into background.

This pull request does just that: it registers with UIApplication status updates so that it can disable, if needed, the location manager when entering background mode and reenable it when application returns to foreground.
