### PR TITLE
annotation.enable enhancement from mapbox/mapbox-ios-sdk#141

### DIFF
--- a/MapView/Map/RMAnnotation.h
+++ b/MapView/Map/RMAnnotation.h
@@ -78,7 +78,7 @@
 @property (nonatomic, assign) RMProjectedRect  projectedBoundingBox;
 @property (nonatomic, assign) BOOL hasBoundingBox;
 
-/** Whether the annotation is currently enabled on the map view. Defaults to `YES`. */
+/** Whether touch events for the annotation's layer are recognized. Defaults to `YES`. */
 @property (nonatomic, assign) BOOL enabled;
 
 /** Whether the annotation should be clustered when map view clustering is enabled. Defaults to `YES`. */

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2996,6 +2996,7 @@
         _accuracyCircleAnnotation = [[RMAnnotation annotationWithMapView:self coordinate:newLocation.coordinate andTitle:nil] retain];
         _accuracyCircleAnnotation.annotationType = kRMAccuracyCircleAnnotationTypeName;
         _accuracyCircleAnnotation.clusteringEnabled = NO;
+        _accuracyCircleAnnotation.enabled = NO;
         _accuracyCircleAnnotation.layer = [[RMCircle alloc] initWithView:self radiusInMeters:newLocation.horizontalAccuracy];
         _accuracyCircleAnnotation.layer.zPosition = -MAXFLOAT;
         _accuracyCircleAnnotation.isUserLocationAnnotation = YES;
@@ -3019,6 +3020,7 @@
         _trackingHaloAnnotation = [[RMAnnotation annotationWithMapView:self coordinate:newLocation.coordinate andTitle:nil] retain];
         _trackingHaloAnnotation.annotationType = kRMTrackingHaloAnnotationTypeName;
         _trackingHaloAnnotation.clusteringEnabled = NO;
+        _trackingHaloAnnotation.enabled = NO;
 
         // create image marker
         //


### PR DESCRIPTION
This brings over some enhancements to annotation touch events. 

Previously, `annotation.enable` could be set, but wouldn't do anything. This makes the overlay layer disregard the annotation in hit testing (via hiding). 

It also makes some tweaks to the user location stuff so that the tracking halo and accuracy circle can't be touched, as well as ensures that the user location layer can register touches in the event of compass tracking, since a dummy user location image view is actually displayed and the annotation layer is not. 

This lets the dev disable any annotations from touches while still showing them, as well as disable touches to the user location by using `mapView.userLocation.enabled = NO` if they so choose (since it works like any other annotation). 
