### PR TITLE
RMMapTiledLayerView::drawLayer calls URLForTile

### DIFF
--- a/MapView/Map/RMOpenSeaMapSource.m
+++ b/MapView/Map/RMOpenSeaMapSource.m
@@ -40,6 +40,11 @@
 	return self;
 }
 
+- (NSURL *)URLForTile:(RMTile)tile
+{
+    return [[self URLsForTile:tile] lastObject];
+}
+
 - (NSArray *)URLsForTile:(RMTile)tile
 {
 	NSAssert4(((tile.zoom >= self.minZoom) && (tile.zoom <= self.maxZoom)),


### PR DESCRIPTION
in drawLayer:inContext URLForTile is invoked on ~ line 179 (in the sync block). 

This prevents apps using the SeaMap layer source from crashing.
