### PR TITLE
WMS Tile Source

### DIFF
--- a/MapView/Map/RMWMS.h
+++ b/MapView/Map/RMWMS.h
@@ -1,0 +1,74 @@
+//
+//  RMWMS.h
+//
+// Copyright (c) 2008-2011, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+
+@interface RMWMS : NSObject {
+
+    NSString *urlPrefix;
+    NSString *layers;
+    NSString *styles;
+    NSString *queryLayers;
+    NSString *crs;
+    BOOL queryable;
+    NSString *infoFormat;
+    NSString *format;
+    NSString *service;
+    NSString *version;
+    NSString *exceptions;
+    NSString *extraKeyValues;
+    
+}
+
+@property (retain) NSString *urlPrefix;
+@property (retain) NSString *layers;
+@property (retain) NSString *styles;
+@property (retain) NSString *queryLayers;
+@property (retain) NSString *crs;
+@property BOOL queryable;
+@property (retain) NSString *infoFormat;
+@property (retain) NSString *format;
+@property (retain) NSString *service;
+@property (retain) NSString *version;
+@property (retain) NSString *exceptions;
+@property (retain) NSString *extraKeyValues;
+
+-(NSString *)createGetMapForBbox:(NSString *)bbox size:(CGSize)size;
+-(NSString *)createGetFeatureInfoForBbox:(NSString *)bbox size:(CGSize)size point:(CGPoint)point;
+-(NSString *)createGetCapabilities;
+
+-(BOOL)isVisible;
+-(BOOL)selected:(NSString *)layerName;
+-(void)select:(NSString *)layerName queryable:(BOOL)queryable;
+-(void)deselect:(NSString *)layerName;
+-(void)setSelectedLayerNames:(NSArray *)layerNames;
+-(NSArray *)selectedLayerNames;
+
+-(void)setExtraKeyValueDictionary:(NSDictionary *)kvd;
+
+@end

--- a/MapView/Map/RMWMS.m
+++ b/MapView/Map/RMWMS.m
@@ -1,0 +1,218 @@
+//
+//  RMWMS.m
+//
+// Copyright (c) 2008-2011, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import "RMWMS.h"
+
+@implementation RMWMS
+
+@synthesize layers;
+@synthesize styles;
+@synthesize queryLayers;
+@synthesize queryable;
+@synthesize crs;
+@synthesize infoFormat;
+@synthesize format;
+@synthesize service;
+@synthesize version;
+@synthesize exceptions;
+@synthesize extraKeyValues;
+
+- (id) init
+{
+    self = [super init];
+    if (self != nil) {
+        // default values
+        [self setInfoFormat:@"text/html"];
+        [self setCrs:@"EPSG:900913"];
+        [self setLayers:@""];
+        [self setQueryLayers:@""];
+        [self setStyles:@""];
+        [self setFormat:@"image/png"];
+        [self setService:@"WMS"];
+        [self setVersion:@"1.1.1"];
+        [self setExceptions:@"application/vnd.ogc.se_inimage"];
+        [self setExtraKeyValues:@""];
+    }
+    return self;
+}
+
+-(void)setUrlPrefix:(NSString *)newUrlPrefix
+{
+    if (newUrlPrefix) {
+        if (!([newUrlPrefix hasSuffix:@"?"]||[newUrlPrefix hasSuffix:@"&"])) {
+            if ([newUrlPrefix rangeOfString:@"?"].location == NSNotFound) {
+                newUrlPrefix = [newUrlPrefix stringByAppendingString:@"?"];
+            } else {
+                newUrlPrefix = [newUrlPrefix stringByAppendingString:@"&"];
+            }
+        }
+    }
+    
+    [urlPrefix release];
+    urlPrefix = [newUrlPrefix retain];
+}
+
+-(NSString *)urlPrefix
+{
+    return urlPrefix;
+}
+
+-(NSString *)createBaseGet:(NSString *)bbox size:(CGSize)size
+{
+    return [NSString
+            stringWithFormat:@"%@FORMAT=%@&SERVICE=%@&VERSION=%@&EXCEPTIONS=%@&SRS=%@&BBOX=%@&WIDTH=%.0f&HEIGHT=%.0f&LAYERS=%@&STYLES=%@%@", 
+            urlPrefix, format, service, version, exceptions, crs, bbox, size.width, size.height, layers, styles, extraKeyValues];
+}
+
+-(NSString *)createGetMapForBbox:(NSString *)bbox size:(CGSize)size
+{
+    return [NSString stringWithFormat:@"%@&REQUEST=GetMap", [self createBaseGet:bbox size:size]];
+}
+
+-(NSString *)createGetFeatureInfoForBbox:(NSString *)bbox size:(CGSize)size point:(CGPoint)point
+{
+    return [NSString 
+            stringWithFormat:@"%@&REQUEST=GetFeatureInfo&INFO_FORMAT=%@&X=%.0f&Y=%.0f&QUERY_LAYERS=%@", 
+            [self createBaseGet:bbox size:size], infoFormat, point.x, point.y, queryLayers];
+}
+
+-(NSString *)createGetCapabilities
+{
+    return [NSString stringWithFormat:@"%@SERVICE=%@&VERSION=%@&REQUEST=GetCapabilities", urlPrefix, service, version];
+}
+
+-(BOOL)isVisible
+{
+    return layers.length > 0;
+}
+
+-(void)setExtraKeyValueDictionary:(NSDictionary *)kvd
+{
+    NSMutableString *s = [NSMutableString string];
+    for (NSString *key in kvd) {
+        [s appendString:@"&"];
+        [s appendString:key];
+        [s appendString:@"="];
+        NSString *value = [kvd objectForKey:key];
+        [s appendString:[value stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }
+    [self setExtraKeyValues:[NSString stringWithString:s]];
+}
+
+// [ layerA, layer B ] -> layerA,layerB
++(NSString *)escapeAndJoin:(NSArray *)elements
+{
+    NSMutableArray *encoded = [NSMutableArray array];
+    for (NSString *element in elements) {
+        [encoded addObject:[element stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }
+    return [encoded componentsJoinedByString:@","];
+}
+
+// layerA,layerB -> [ layerA, layer B ]
++(NSArray *)splitAndDecode:(NSString *)joined
+{
+    NSMutableArray *split = [NSMutableArray array];
+    if ([joined length] == 0) {
+        return split;
+    }
+    for (NSString *element in [joined componentsSeparatedByString:@","]) {
+        [split addObject:[element stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }
+    return split;
+}
+
+-(NSArray *)selectedLayerNames
+{
+    return [RMWMS splitAndDecode:layers];
+}
+
+-(void)setSelectedLayerNames:(NSArray *)layerNames
+{
+    [self setLayers:[RMWMS escapeAndJoin:layerNames]];
+}
+
+-(NSArray *)selectedQueryLayerNames
+{
+    return [RMWMS splitAndDecode:queryLayers];
+}
+
+-(void)setSelectedQueryLayerNames:(NSArray *)layerNames
+{
+    [self setQueryLayers:[RMWMS escapeAndJoin:layerNames]];
+}
+
+-(BOOL)selected:(NSString *)layerName
+{
+    return [[self selectedLayerNames] containsObject:layerName];
+}
+
+-(void)select:(NSString *)layerName queryable:(BOOL)isQueryable
+{
+    NSMutableArray *array = [NSMutableArray arrayWithArray:[self selectedLayerNames]];
+    if (![array containsObject:layerName]) {
+        [array addObject:layerName];
+        [self setSelectedLayerNames:array];
+    }
+    
+    if (isQueryable) {
+        array = [NSMutableArray arrayWithArray:[self selectedQueryLayerNames]];
+        if (![array containsObject:layerName]) {
+            [array addObject:layerName];
+            [self setSelectedQueryLayerNames:array];
+        }
+    }
+}
+
+-(void)deselect:(NSString *)layerName
+{
+    NSMutableArray *array = [NSMutableArray arrayWithArray:[self selectedLayerNames]];
+    [array removeObject:layerName];
+    [self setSelectedLayerNames:array];
+    
+    array = [NSMutableArray arrayWithArray:[self selectedQueryLayerNames]];
+    [array removeObject:layerName];
+    [self setSelectedQueryLayerNames:array];
+}
+
+- (void) dealloc
+{
+    [self setUrlPrefix:nil];
+    [self setLayers:nil];
+    [self setStyles:nil];
+    [self setQueryLayers:nil];
+    [self setCrs:nil];
+    [self setInfoFormat:nil];
+    [self setFormat:nil];
+    [self setService:nil];
+    [self setVersion:nil];
+    [self setExceptions:nil];
+    [self setExtraKeyValues:nil];
+    [super dealloc];
+}
+
+@end

--- a/MapView/Map/RMWMSSource.h
+++ b/MapView/Map/RMWMSSource.h
@@ -1,0 +1,83 @@
+//
+//  RMWMSSource.h
+//
+// Copyright (c) 2008-2011, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+#import "RMMapView.h"
+#import "RMAbstractWebMapSource.h"
+#import "RMTile.h"
+#import "RMWMS.h"
+
+/*! 
+ \brief Subclass of RMAbstractWebMapSource for access to OGC WMS Server.
+ 
+ Example:
+ RMWMS *wms = [[RMWMS alloc] init];
+ wms.urlPrefix = @"http://vmap0.tiles.osgeo.org/wms/vmap0";
+ wms.layers = @"basic";
+ RMWMSSource *wmsSource = [[RMWMSSource alloc] init];
+ wmsSource.wms = wms;
+ wmsSource.uniqueTilecacheKey = @"abc";
+ [mapView setTileSource:wmsSource];
+ [wms release];
+ [wmsSource release];
+ */
+@interface RMWMSSource : RMAbstractWebMapSource {
+
+    float initialResolution;
+    float originShift;
+    
+    float minZoom;
+    float maxZoom;
+    NSString *name;
+    NSString *shortName;
+    NSString *shortAttribution;
+    NSString *longDescription;
+    NSString *longAttribution;
+    NSString *uniqueTilecacheKey;
+    
+    RMWMS *wms;
+    
+}
+
+@property float minZoom;
+@property float maxZoom;
+@property (retain) NSString *name;
+@property (retain) NSString *shortName;
+@property (retain) NSString *shortAttribution;
+@property (retain) NSString *longDescription;
+@property (retain) NSString *longAttribution;
+@property (retain) NSString *uniqueTilecacheKey;
+@property (retain) RMWMS *wms;
+
+-(NSString*) bboxForTile: (RMTile) tile;
+-(float) resolutionAtZoom : (int) zoom ;
+-(CGPoint) pixelsToMetersAtZoom: (int) px PixelY:(int)py atResolution:(float) resolution ;
+
+- (NSString *)featureInfoUrlForPoint:(CGPoint)point inMap:(RMMapView *)mapView;
+
+@end

--- a/MapView/Map/RMWMSSource.m
+++ b/MapView/Map/RMWMSSource.m
@@ -1,0 +1,116 @@
+//
+//  RMWMSSource.m
+//
+// Copyright (c) 2008-2009, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import "RMWMSSource.h"
+
+@implementation RMWMSSource
+
+@synthesize minZoom;
+@synthesize maxZoom;
+@synthesize name;
+@synthesize shortName;
+@synthesize shortAttribution;
+@synthesize longDescription;
+@synthesize longAttribution;
+@synthesize uniqueTilecacheKey;
+@synthesize wms;
+
+-(id) init 
+{ 
+    if (![super init]) 
+        return nil; 
+    
+    // The code below is based on the followin URL, but fixed for this use
+    // http://groups.google.com/group/route-me-map/browse_thread/thread/b6aa3757d46055aa/c93e7b0c861973e5?lnk=gst&q=900913#c93e7b0c861973e5
+    
+    initialResolution = 2 * M_PI * 6378137 / kDefaultTileSize; 
+    originShift = 2 * M_PI * 6378137 / 2.0; 
+    
+    [self setMinZoom:1.0];
+    [self setMaxZoom:18.0];
+
+    // some default values
+    [self setName:@"wms"];
+    [self setUniqueTilecacheKey:@"wms"];
+    
+    return self; 
+} 
+
+-(NSString*) bboxForTile: (RMTile) tile
+{
+    float resolution = [self resolutionAtZoom: tile.zoom];
+    CGPoint min = [self pixelsToMetersAtZoom: (tile.x     * kDefaultTileSize) PixelY:((tile.y+1) * kDefaultTileSize) atResolution:resolution];
+    CGPoint max = [self pixelsToMetersAtZoom: ((tile.x+1) * kDefaultTileSize) PixelY:((tile.y)   * kDefaultTileSize) atResolution:resolution];
+    return [NSString stringWithFormat:@"%f,%f,%f,%f", 
+            min.x, min.y, max.x, max.y];
+}
+
+- (NSURL *)URLForTile:(RMTile)tile
+{
+    NSString *bbox = [self bboxForTile:tile];
+    return [NSURL URLWithString:[wms createGetMapForBbox:bbox size:CGSizeMake(kDefaultTileSize, kDefaultTileSize)]];
+}
+
+//Resolution (meters/pixel) for given zoom level (measured at Equator) 
+-(float) resolutionAtZoom : (int) zoom 
+{ 
+    return initialResolution /pow (2,zoom); 
+} 
+
+// Converts pixel coordinates in given resolution to EPSG: 900913 
+-(CGPoint) pixelsToMetersAtZoom: (int) px PixelY:(int)py atResolution:(float) resolution 
+{ 
+    CGPoint meters; 
+    meters.x = (px * resolution) - originShift; 
+    meters.y = originShift - (py * resolution); 
+    return meters; 
+}
+
+- (NSString *)featureInfoUrlForPoint:(CGPoint)point inMap:(RMMapView *)mapView;
+{
+    // convert to where the user clicked in the tile
+    RMProjectedPoint xy = [mapView pixelToProjectedPoint:point];
+    RMFractalTileProjection *tileProjection = (RMFractalTileProjection *)[mapView mercatorToTileProjection];
+    RMTilePoint tilePoint = [tileProjection project:xy atZoom:[mapView zoom]];
+    float x = kDefaultTileSize * tilePoint.offset.x;
+    float y = kDefaultTileSize * tilePoint.offset.y;
+    NSString *bbox = [self bboxForTile:tilePoint.tile];
+    return [wms createGetFeatureInfoForBbox:bbox
+                                       size:CGSizeMake(kDefaultTileSize, kDefaultTileSize)
+                                      point:CGPointMake(x, y)];
+}
+
+
+- (void) dealloc
+{
+    [self setName:nil];
+    [self setUniqueTilecacheKey:nil];
+    [self setWms:nil];
+    [super dealloc];
+}
+
+@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		23A0AAEB0EB90AA6003A4521 /* RMFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A0AAEA0EB90AA6003A4521 /* RMFoundation.h */; };
 		25757F4F1291C8640083D504 /* RMCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 25757F4D1291C8640083D504 /* RMCircle.h */; };
 		25757F501291C8640083D504 /* RMCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 25757F4E1291C8640083D504 /* RMCircle.m */; };
+		444FEC1E17A5BF7100F3798C /* RMWMS.h in Headers */ = {isa = PBXBuildFile; fileRef = 444FEC1A17A5BF7100F3798C /* RMWMS.h */; };
+		444FEC1F17A5BF7100F3798C /* RMWMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 444FEC1B17A5BF7100F3798C /* RMWMS.m */; };
+		444FEC2017A5BF7100F3798C /* RMWMSSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 444FEC1C17A5BF7100F3798C /* RMWMSSource.h */; };
+		444FEC2117A5BF7100F3798C /* RMWMSSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 444FEC1D17A5BF7100F3798C /* RMWMSSource.m */; };
 		96492C400FA8AD3400EBA6D2 /* RMGlobalConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 96492C3F0FA8AD3400EBA6D2 /* RMGlobalConstants.h */; };
 		B1EB26C610B5D8E6009F8658 /* RMNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EB26C510B5D8E6009F8658 /* RMNotifications.h */; };
 		B8474BA40EB40094006A0BC1 /* RMDatabaseCache.h in Headers */ = {isa = PBXBuildFile; fileRef = B8474B980EB40094006A0BC1 /* RMDatabaseCache.h */; };
@@ -181,6 +185,10 @@
 		25757F4D1291C8640083D504 /* RMCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMCircle.h; sourceTree = "<group>"; };
 		25757F4E1291C8640083D504 /* RMCircle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMCircle.m; sourceTree = "<group>"; };
 		288765A40DF7441C002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		444FEC1A17A5BF7100F3798C /* RMWMS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMWMS.h; sourceTree = "<group>"; };
+		444FEC1B17A5BF7100F3798C /* RMWMS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMWMS.m; sourceTree = "<group>"; };
+		444FEC1C17A5BF7100F3798C /* RMWMSSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMWMSSource.h; sourceTree = "<group>"; };
+		444FEC1D17A5BF7100F3798C /* RMWMSSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMWMSSource.m; sourceTree = "<group>"; };
 		96492C3F0FA8AD3400EBA6D2 /* RMGlobalConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGlobalConstants.h; sourceTree = "<group>"; };
 		B1EB26C510B5D8E6009F8658 /* RMNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMNotifications.h; sourceTree = "<group>"; };
 		B83E64B60E80E73F001663B6 /* RMPixel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMPixel.h; sourceTree = "<group>"; };
@@ -307,6 +315,10 @@
 				B83E64EE0E80E73F001663B6 /* RMOpenStreetMapSource.m */,
 				DD4195C7162356900049E6BA /* RMBingSource.h */,
 				DD4195C8162356900049E6BA /* RMBingSource.m */,
+				444FEC1A17A5BF7100F3798C /* RMWMS.h */,
+				444FEC1B17A5BF7100F3798C /* RMWMS.m */,
+				444FEC1C17A5BF7100F3798C /* RMWMSSource.h */,
+				444FEC1D17A5BF7100F3798C /* RMWMSSource.m */,
 			);
 			name = "Map Sources";
 			sourceTree = "<group>";
@@ -605,6 +617,8 @@
 				DD4195C9162356900049E6BA /* RMBingSource.h in Headers */,
 				DD1E3C6E161F954F004FC649 /* SMCalloutView.h in Headers */,
 				DD6B651B16A9ECD8007D1CBA /* MapView_Prefix.pch in Headers */,
+				444FEC1E17A5BF7100F3798C /* RMWMS.h in Headers */,
+				444FEC2017A5BF7100F3798C /* RMWMSSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -746,6 +760,8 @@
 				DD41960216250ED40049E6BA /* RMTileCacheDownloadOperation.m in Sources */,
 				DD4195CA162356900049E6BA /* RMBingSource.m in Sources */,
 				DD1E3C6F161F954F004FC649 /* SMCalloutView.m in Sources */,
+				444FEC1F17A5BF7100F3798C /* RMWMS.m in Sources */,
+				444FEC2117A5BF7100F3798C /* RMWMSSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Long time ago, I added a RMWMSSource to /route-me/route-me. This is the same thing but with some minor changes from my project + some changes to confirm with the Alpstein fork.

Example (from RMWMSSource.h):

 RMWMS *wms = [[RMWMS alloc] init];
 wms.urlPrefix = @"http://vmap0.tiles.osgeo.org/wms/vmap0";
 wms.layers = @"basic";
 RMWMSSource *wmsSource = [[RMWMSSource alloc] init];
 wmsSource.wms = wms;
 wmsSource.uniqueTilecacheKey = @"abc";
 [mapView setTileSource:wmsSource];
 [wms release];
 [wmsSource release];
