### PR TITLE
Fix for partial caching of layered web tiles

### DIFF
--- a/MapView/Map/RMAbstractWebMapSource.m
+++ b/MapView/Map/RMAbstractWebMapSource.m
@@ -123,6 +123,7 @@
 
     // Load the tiles
     NSArray *URLs = [self URLsForTile:tile];
+    NSUInteger numTileImagesLoaded = 0;
 
     if ([URLs count] > 1)
     {
@@ -186,6 +187,7 @@
                 {
                     image = [UIImage imageWithData:tileData];
                 }
+                numTileImagesLoaded = numTileImagesLoaded + 1;
             }
         }
     }
@@ -201,9 +203,10 @@
             if (response.statusCode == HTTP_404_NOT_FOUND)
                 break;
         }
+        numTileImagesLoaded = 1;
     }
 
-    if (image && self.isCacheable)
+    if (image && self.isCacheable && numTileImagesLoaded == [URLs count])
         [tileCache addImage:image forTile:tile withCacheKey:[self uniqueTilecacheKey]];
 
     [activeDownloadsCondition lock];


### PR DESCRIPTION
This change fixes an issue we had with composit web tiles. We are using OpenSeaMap tiles as a layer above OpenStreetMap tiles. If for whatever reason one of the layer images could not be loaded but the other image was loaded, the partial image (e.g. containing only the transparent OpenSeaMap layer) ended up in the route me cache and the full composit image was not requested again. To prevent this I've added a counter that is increased whenever a layer image is loaded. This counter is checked against the number of URLs. If the number of loaded layer images is smaller than the number of URLs, the composit image is not cached.
This is my first pull request ever, so I'm sorry if I've done something wrong. Please let me know.

Cheers & thanks for the great work you have done with your route-me fork.
