### PR TITLE
Added properties for _mapScrollView and _overlayView to make them accessible

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -122,6 +122,12 @@ typedef NS_ENUM(NSUInteger, RMMapDecelerationMode) {
 
 @property (nonatomic, assign) NSUInteger boundingMask;
 
+/** The scroll view containing the map tiles */
+@property (nonatomic, assign, readonly) RMMapScrollView *mapScrollView;
+
+/** The view used for map overlays like annotations */
+@property (nonatomic, assign, readonly) RMMapOverlayView *overlayView;
+
 /** A custom, static view to use behind the map tiles. The default behavior is to use grid imagery that moves with map panning like MapKit. */
 @property (nonatomic, retain) UIView *backgroundView;
 

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2153,6 +2153,16 @@
 
 #pragma mark - Properties
 
+- (RMMapScrollView *)mapScrollView
+{
+    return [[_mapScrollView retain] autorelease];
+}
+
+- (RMMapOverlayView *)overlayView
+{
+    return [[_overlayView retain] autorelease];
+}
+
 - (UIView *)backgroundView
 {
     return [[_backgroundView retain] autorelease];


### PR DESCRIPTION
For two of our projects using route-me we need direct access to the mapScrollView and the overlayView. So I've added some properties. It would be nice to see those changes end up in the original Alpstein fork.
