### PR TITLE
Allow users of this library to turn off clustering above a certain zoom ...

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -356,6 +356,15 @@ typedef NS_ENUM(NSUInteger, RMMapDecelerationMode) {
 @property (nonatomic, assign) CGSize clusterMarkerSize;
 @property (nonatomic, assign) CGSize clusterAreaSize;
 
+
+/** Whether to turn clustering off above a certain zoom level. Only relevant if clustering is enabled. Defaults to `NO`. */
+@property (nonatomic, assign) BOOL enableClusteringByZoomLevel;
+
+
+/** Zoom level where clustering is on (below) or off (above). Only relevant if clustering by zoom level is enabled. Defaults to `NO`. */
+@property (nonatomic, assign) float zoomLevelForClustering;
+
+
 @property (nonatomic, readonly) RMTileSourcesContainer *tileSourcesContainer;
 
 /** @name Managing Tile Sources */

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -2668,9 +2668,17 @@
         boundingBox.origin.y -= boundingBoxBuffer;
         boundingBox.size.width += (2.0 * boundingBoxBuffer);
         boundingBox.size.height += (2.0 * boundingBoxBuffer);
+        
+        
+        BOOL clusterAnnotationsAtThisZoomLevel = self.enableClustering;
+        if (self.enableClustering && self.enableClusteringByZoomLevel) {
+            if (self.zoom > self.zoomLevelForClustering) {
+                clusterAnnotationsAtThisZoomLevel = NO;
+            }
+        }
 
         NSArray *annotationsToCorrect = [self.quadTree annotationsInProjectedRect:boundingBox
-                                                         createClusterAnnotations:self.enableClustering
+                                                         createClusterAnnotations:clusterAnnotationsAtThisZoomLevel
                                                          withProjectedClusterSize:RMProjectedSizeMake(self.clusterAreaSize.width * _metersPerPixel, self.clusterAreaSize.height * _metersPerPixel)
                                                     andProjectedClusterMarkerSize:RMProjectedSizeMake(self.clusterMarkerSize.width * _metersPerPixel, self.clusterMarkerSize.height * _metersPerPixel)
                                                                 findGravityCenter:self.positionClusterMarkersAtTheGravityCenter];


### PR DESCRIPTION
We had an issue where the clustering algorithm would never let users zoom all the way in to the annotations. At a certain zoom level, an option to turn off clustering would solve this. 

Happy to consider other ways of doing this, if there is a better way.
